### PR TITLE
Add Base.parent method

### DIFF
--- a/src/stridedview.jl
+++ b/src/stridedview.jl
@@ -39,6 +39,7 @@ Base.stride(a::StridedView{<:Any, 0}, n::Int) = 1
 Base.stride(a::StridedView{<:Any, N}, n::Int) where N =
     (n <= N) ? a.strides[n] : a.strides[N]*a.size[N]
 offset(a::StridedView) = a.offset
+Base.parent(a::StridedView) = a.parent
 
 function blasstrides(a::StridedView{<:Any,2})
     # canonialize strides to make compatible with gemm


### PR DESCRIPTION
I think this solves the following error (on TensorOperations v3, but not on v2):
```julia
using TensorOperations, Strided

b0 = rand(3,2);
f0 = rand(2,3,4);

bison2 = @strided permutedims(b0, (2,1))
ferret2 = @strided permutedims(f0, (1, 2, 3))

@tensor finch[k] := ferret2[i, j, k] * bison2[i, j]

# ERROR: StackOverflowError:
# Stacktrace:
#  [1] memsize(::StridedView{Float64,2,Array{Float64,1},typeof(identity)}) at /Users/me/.julia/packages/TensorOperations/1TnL0/src/implementation/stridedarray.jl:5 (repeats 79984 times)

TensorOperations.memsize(bison2) # same
```