### PR TITLE
Change `kw.data` -> `values(kw)`

### DIFF
--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -1,5 +1,5 @@
 Base.mapreduce(f, op, A::AbstractStridedView; dims=:, kw...) =
-    Base._mapreduce_dim(f, op, kw.data, A, dims)
+    Base._mapreduce_dim(f, op, values(kw), A, dims)
 
 Base._mapreduce_dim(f, op, nt::NamedTuple{(:init,)}, A::AbstractStridedView, ::Colon) =
     _mapreduce(f, op, A, nt)


### PR DESCRIPTION
This should fix the following warning on Julia nightly:
```
┌ Warning: use values(kwargs) and keys(kwargs) instead of kwargs.data and kwargs.itr
```