### PR TITLE
Bugfix blasstrides

### DIFF
--- a/src/linalg.jl
+++ b/src/linalg.jl
@@ -162,10 +162,10 @@ function __mul!(C::StridedView{<:Any,2}, A::StridedView{<:Any,2}, B::StridedView
     return C
 end
 
-function blasstrides(a::StridedView{<:Any,2})
-    # canonialize strides to make compatible with gemm
+function blasstrides(a::StridedView{T,2,A,F}) where {T,A<:DenseArray,F}
+    # canonicalize strides to make compatible with gemm
     if size(a, 2) == 1 && stride(a, 1) == 1
-        return StridedView(a.parent, a.size, (1, size(a, 1)), a.offset, a.op)
+        return StridedView{T,2,A,F}(a.parent, a.size, (1, size(a, 1)), a.offset, a.op)
     else
         return a
     end

--- a/test/blasmultests.jl
+++ b/test/blasmultests.jl
@@ -30,5 +30,33 @@ for T1 in (Float32, Float64, Complex{Float32}, Complex{Float64})
                 end
             end
         end
+        
+        @testset "Tensor product with StridedView: $T1 times $T2" begin
+            d = 10
+            A1 = rand(T1, (d, 1))
+            A2 = rand(T2, (1, d))
+            T3 = promote_type(T1, T2)
+            A3 = rand(T3, (d, d))
+            A4 = rand(T3, (d, d))
+            B1 = StridedView(copy(A1))
+            B2 = StridedView(copy(A2))
+            B3 = StridedView(copy(A3))
+            B4 = StridedView(copy(A4))
+            α = randn(T3)
+            β = randn(T3)
+            for op1 in (identity, conj)
+                @test op1(A1) == op1(B1)
+                for op2 in (identity, conj)
+                    @test op1(A1) * op2(A2) ≈ op1(B1) * op2(B2)
+                    for op3 in (identity, conj, transpose, adjoint)
+                        α = randn(T3)
+                        β = randn(T3)
+                        copyto!(B3, B4)
+                        mul!(op3(B3), op1(B1), op2(B2), α, β)
+                        @test B3 ≈ op3(β) * A4 + op3(α * op1(A1) * op2(A2)) # op3 is its own inverse
+                    end
+                end
+            end
+        end
     end
 end


### PR DESCRIPTION
Constructor `StridedView` always normalizes strides, thus undoing the work of `blasstrides`. This leads to issues when calling `BLAS.gemm!`. This can be resolved by calling the fully typed constructor `StridedView{T,2,A,F}`.
```julia
using Strided
A = zeros(2,1)
```

Previously:

```julia-repl
julia> strides(A)
(1, 2)
julia> strides(StridedView(A))
(1, 1)
julia> strides(Strided.blasstrides(StridedView(A)))
(1, 1)
```

Now:
```julia-repl
julia> strides(A)
(1, 2)
julia> strides(StridedView(A))
(1, 1)
julia> strides(Strided.blasstrides(StridedView(A)))
(1, 2)
```