### PR TITLE
Fix empty StridedView broadcasting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Strided"
 uuid = "5e0ebb24-38b0-5f93-81fe-25c709ecae67"
-version = "2.3.4"
+version = "2.3.5"
 authors = ["Lukas Devos <lukas.devos@ugent.be>", "Maarten Van Damme <maartenvd1994@gmail.com>", "Jutho Haegeman <jutho.haegeman@ugent.be>"]
 
 [deps]

--- a/src/broadcast.jl
+++ b/src/broadcast.jl
@@ -30,13 +30,16 @@ Base.dotview(a::StridedView{<:Any, N}, I::Vararg{SliceIndex, N}) where {N} = get
         dest::StridedView{<:Any, N},
         bc::Broadcasted{StridedArrayStyle{N}}
     ) where {N}
+    dims = size(dest)
+    any(isequal(0), dims) && return dest
+
     # convert to map
 
     # flatten and only keep the StridedView arguments
     # promote StridedView to have same size, by giving artificial zero strides
-    stridedargs = promoteshape(size(dest), capturestridedargs(bc)...)
+    stridedargs = promoteshape(dims, capturestridedargs(bc)...)
     c = make_capture(bc)
-    _mapreduce_fuse!(c, nothing, nothing, size(dest), (dest, stridedargs...))
+    _mapreduce_fuse!(c, nothing, nothing, dims, (dest, stridedargs...))
     return dest
 end
 

--- a/test/othertests.jl
+++ b/test/othertests.jl
@@ -65,6 +65,14 @@ end
     end
 end
 
+@testset "broadcast with zero-length StridedView" begin
+    @testset for T in (Float32, Float64, ComplexF32, ComplexF64)
+        A1 = StridedView(zeros(T, (2, 0)))
+        A2 = StridedView(zeros(T, (2, 0)))
+        @test (A1 .+ A2) == StridedView(zeros(T, (2, 0)))
+    end
+end
+
 @testset "mapreduce with StridedView" begin
     @testset for T in (Float32, Float64, ComplexF32, ComplexF64)
         R1 = rand(T, (10, 10, 10, 10, 10, 10))


### PR DESCRIPTION
This fixes a bug I came across when broadcasting empty StridedViews. Without this change, I see the following:
```julia
(dev) pkg> st
Status `~/.julia/dev/Strided/dev/Project.toml`
  [5e0ebb24] Strided v2.3.4

julia> using Strided

julia> A1 = StridedView(randn(2, 0))
2×0 StridedView{Float64, 2, Memory{Float64}, typeof(identity)}

julia> A2 = StridedView(randn(2, 0))
2×0 StridedView{Float64, 2, Memory{Float64}, typeof(identity)}

julia> A1 .+ A2
ERROR: ArgumentError: step cannot be zero
Stacktrace:
  [1] steprange_last
    @ ./range.jl:349 [inlined]
  [2] StepRange
    @ ./range.jl:336 [inlined]
  [3] StepRange
    @ ./range.jl:391 [inlined]
  [4] _colon
    @ ./range.jl:24 [inlined]
  [5] Colon
    @ ./range.jl:22 [inlined]
  [6] macro expansion
    @ ~/.julia/packages/Strided/yfmeB/src/mapreduce.jl:421 [inlined]
  [7] _mapreduce_kernel!(f::Strided.CaptureArgs{…}, op::Nothing, initop::Nothing, dims::Tuple{…}, blocks::Tuple{…}, arrays::Tuple{…}, strides::Tuple{…}, offsets::Tuple{…})
    @ Strided ~/.julia/packages/Strided/yfmeB/src/mapreduce.jl:257
  [8] _mapreduce_block!(f::Strided.CaptureArgs{…}, op::Nothing, initop::Nothing, dims::Tuple{…}, strides::Tuple{…}, offsets::Tuple{…}, costs::Tuple{…}, arrays::Tuple{…})
    @ Strided ~/.julia/packages/Strided/yfmeB/src/mapreduce.jl:170
  [9] _mapreduce_order!(f::Strided.CaptureArgs{…}, op::Nothing, initop::Nothing, dims::Tuple{…}, strides::Tuple{…}, arrays::Tuple{…})
    @ Strided ~/.julia/packages/Strided/yfmeB/src/mapreduce.jl:154
 [10] _mapreduce_fuse!
    @ ~/.julia/packages/Strided/yfmeB/src/mapreduce.jl:130 [inlined]
 [11] copyto!
    @ ~/.julia/packages/Strided/yfmeB/src/broadcast.jl:39 [inlined]
 [12] copy
    @ ./broadcast.jl:919 [inlined]
 [13] materialize(bc::Base.Broadcast.Broadcasted{Strided.StridedArrayStyle{…}, Nothing, typeof(+), Tuple{…}})
    @ Base.Broadcast ./broadcast.jl:894
 [14] top-level scope
    @ REPL[9]:1
 [15] top-level scope
    @ REPL:1
Some type information was truncated. Use `show(err)` to see complete types.

```
Other codepaths like `map[!]` seem to already have this kind of check for the empty case (before calling `_mapreduce_fuse!`).