### PR TITLE
Slow but working copyto

### DIFF
--- a/ext/StridedGPUArraysExt.jl
+++ b/ext/StridedGPUArraysExt.jl
@@ -20,6 +20,14 @@ function Base.copy!(dst::AbstractArray{TD, ND}, src::StridedView{TS, NS, TAS, FS
     return dst
 end
 
+function Base.copyto!(dest::StridedView{T, N, <:AnyGPUArray{T}}, bc::Base.Broadcast.Broadcasted{Strided.StridedArrayStyle{N}}) where {T <: Number, N}
+    dims = size(dest)
+    any(isequal(0), dims) && return dest
+
+    GPUArrays._copyto!(dest, bc)
+    return dest
+end
+
 # lifted from GPUArrays.jl
 function Base.fill!(A::StridedView{T, N, TA, F}, x) where {T, N, TA <: AbstractGPUArray{T}, F <: ALL_FS}
     isempty(A) && return A

--- a/ext/StridedGPUArraysExt.jl
+++ b/ext/StridedGPUArraysExt.jl
@@ -42,30 +42,6 @@ function Base.fill!(A::StridedView{T, N, TA, F}, x) where {T, N, TA <: AbstractG
     return A
 end
 
-# kernel-based variant for copying between wrapped GPU arrays
-@kernel function linear_copy_kernel!(dest, dstart, src, sstart, n)
-    i = @index(Global, Linear)
-    if i <= n
-        @inbounds dest[dstart + i - 1] = src[sstart + i - 1]
-    end
-end
-
-function Base.copyto!(
-        dest::StridedView{TD, ND, TAD, FD}, dstart::Integer,
-        src::StridedView{TS, NS, TAS, FS}, sstart::Integer, n::Integer
-    ) where {TD, TS, ND, NS, TAD <: AbstractGPUArray{TD}, TAS <: AbstractGPUArray{TS}, FD, FS}
-    n == 0 && return dest
-    n < 0 && throw(ArgumentError(string("tried to copy n=", n, " elements, but n should be nonnegative")))
-    destinds, srcinds = LinearIndices(dest), LinearIndices(src)
-    (checkbounds(Bool, destinds, dstart) && checkbounds(Bool, destinds, dstart + n - 1)) || throw(BoundsError(dest, dstart:(dstart + n - 1)))
-    (checkbounds(Bool, srcinds, sstart)  && checkbounds(Bool, srcinds, sstart + n - 1))  || throw(BoundsError(src, sstart:(sstart + n - 1)))
-    kernel = linear_copy_kernel!(KernelAbstractions.get_backend(dest))
-    kernel(dest, dstart, src, sstart, n; ndrange = n)
-    return dest
-end
-Base.copyto!(dest::StridedView{TD, ND, TAD, FD}, src::StridedView{TS, NS, TAS, FS}) where {TD, TS, ND, NS, TAD <: AbstractGPUArray{TD}, TAS <: AbstractGPUArray{TS}, FD, FS} = copyto!(dest, 1, src, 1, length(src))
-
-
 function LinearAlgebra.mul!(
         C::StridedView{TC, 2, <:AnyGPUArray{TC}},
         A::StridedView{TA, 2, <:AnyGPUArray{TA}},

--- a/ext/StridedGPUArraysExt.jl
+++ b/ext/StridedGPUArraysExt.jl
@@ -1,6 +1,6 @@
 module StridedGPUArraysExt
 
-using Strided, GPUArrays
+using Strided, GPUArrays, LinearAlgebra
 using GPUArrays: Adapt, KernelAbstractions
 using GPUArrays.KernelAbstractions: @kernel, @index
 
@@ -34,7 +34,29 @@ function Base.fill!(A::StridedView{T, N, TA, F}, x) where {T, N, TA <: AbstractG
     return A
 end
 
-function Strided.__mul!(
+# kernel-based variant for copying between wrapped GPU arrays
+@kernel function linear_copy_kernel!(dest, dstart, src, sstart, n)
+    i = @index(Global, Linear)
+    if i <= n
+        @inbounds dest[dstart+i-1] = src[sstart+i-1]
+    end
+end
+
+function Base.copyto!(dest::StridedView{TD, ND, TAD, FD}, dstart::Integer,
+                      src::StridedView{TS, NS, TAS, FS}, sstart::Integer, n::Integer) where {TD, TS, ND, NS, TAD <: AbstractGPUArray{TD}, TAS <: AbstractGPUArray{TS}, FD, FS}
+    n == 0 && return dest
+    n < 0 && throw(ArgumentError(string("tried to copy n=", n, " elements, but n should be nonnegative")))
+    destinds, srcinds = LinearIndices(dest), LinearIndices(src)
+    (checkbounds(Bool, destinds, dstart) && checkbounds(Bool, destinds, dstart+n-1)) || throw(BoundsError(dest, dstart:dstart+n-1))
+    (checkbounds(Bool, srcinds, sstart)  && checkbounds(Bool, srcinds, sstart+n-1))  || throw(BoundsError(src,  sstart:sstart+n-1))
+    kernel = linear_copy_kernel!(KernelAbstractions.get_backend(dest))
+    kernel(dest, dstart, src, sstart, n; ndrange=n)
+    return dest
+end
+Base.copyto!(dest::StridedView{TD, ND, TAD, FD}, src::StridedView{TS, NS, TAS, FS}) where {TD, TS, ND, NS, TAD <: AbstractGPUArray{TD}, TAS <: AbstractGPUArray{TS}, FD, FS} = copyto!(dest, 1, src, 1, length(src))
+
+
+function LinearAlgebra.mul!(
         C::StridedView{TC, 2, <:AnyGPUArray{TC}},
         A::StridedView{TA, 2, <:AnyGPUArray{TA}},
         B::StridedView{TB, 2, <:AnyGPUArray{TB}},

--- a/ext/StridedGPUArraysExt.jl
+++ b/ext/StridedGPUArraysExt.jl
@@ -38,19 +38,21 @@ end
 @kernel function linear_copy_kernel!(dest, dstart, src, sstart, n)
     i = @index(Global, Linear)
     if i <= n
-        @inbounds dest[dstart+i-1] = src[sstart+i-1]
+        @inbounds dest[dstart + i - 1] = src[sstart + i - 1]
     end
 end
 
-function Base.copyto!(dest::StridedView{TD, ND, TAD, FD}, dstart::Integer,
-                      src::StridedView{TS, NS, TAS, FS}, sstart::Integer, n::Integer) where {TD, TS, ND, NS, TAD <: AbstractGPUArray{TD}, TAS <: AbstractGPUArray{TS}, FD, FS}
+function Base.copyto!(
+        dest::StridedView{TD, ND, TAD, FD}, dstart::Integer,
+        src::StridedView{TS, NS, TAS, FS}, sstart::Integer, n::Integer
+    ) where {TD, TS, ND, NS, TAD <: AbstractGPUArray{TD}, TAS <: AbstractGPUArray{TS}, FD, FS}
     n == 0 && return dest
     n < 0 && throw(ArgumentError(string("tried to copy n=", n, " elements, but n should be nonnegative")))
     destinds, srcinds = LinearIndices(dest), LinearIndices(src)
-    (checkbounds(Bool, destinds, dstart) && checkbounds(Bool, destinds, dstart+n-1)) || throw(BoundsError(dest, dstart:dstart+n-1))
-    (checkbounds(Bool, srcinds, sstart)  && checkbounds(Bool, srcinds, sstart+n-1))  || throw(BoundsError(src,  sstart:sstart+n-1))
+    (checkbounds(Bool, destinds, dstart) && checkbounds(Bool, destinds, dstart + n - 1)) || throw(BoundsError(dest, dstart:(dstart + n - 1)))
+    (checkbounds(Bool, srcinds, sstart)  && checkbounds(Bool, srcinds, sstart + n - 1))  || throw(BoundsError(src, sstart:(sstart + n - 1)))
     kernel = linear_copy_kernel!(KernelAbstractions.get_backend(dest))
-    kernel(dest, dstart, src, sstart, n; ndrange=n)
+    kernel(dest, dstart, src, sstart, n; ndrange = n)
     return dest
 end
 Base.copyto!(dest::StridedView{TD, ND, TAD, FD}, src::StridedView{TS, NS, TAS, FS}) where {TD, TS, ND, NS, TAD <: AbstractGPUArray{TD}, TAS <: AbstractGPUArray{TS}, FD, FS} = copyto!(dest, 1, src, 1, length(src))

--- a/test/amd.jl
+++ b/test/amd.jl
@@ -16,6 +16,12 @@ for T in (Float32, Float64, Complex{Float32}, Complex{Float64})
             axes(f1(A1)) == axes(f2(A2)) || continue
             @test collect(ROCMatrix(copy!(f2(A2), f1(A1)))) == AMDGPU.Adapt.adapt(Vector{T}, copy!(B2, B1))
             @test copy!(zA1, f1(A1)) == copy!(zA2, B1)
+            A3 = ROCArray(randn(T, (m1, m2)))
+            A3c = copy(A3)
+            B3 = f1(StridedView(A3c))
+            @. B1 = 2 * B1 - B3 / 3 # test copyto! of Broadcasted
+            @. A1 = 2 * A1 - A3 / 3 # test copyto! of Broadcasted
+            @test AMDGPU.Adapt.adapt(Vector{T}, f1(A1)) == AMDGPU.Adapt.adapt(Vector{T}, B1)
             x = rand(T)
             @test f1(StridedView(AMDGPU.Adapt.adapt(Vector{T}, fill!(A1c, x)))) == AMDGPU.Adapt.adapt(Vector{T}, fill!(B1, x))
         end

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -12,6 +12,12 @@ for T in (Float32, Float64, Complex{Float32}, Complex{Float64})
             axes(f1(A1)) == axes(f2(A2)) || continue
             @test collect(CuMatrix(copy!(f2(A2), f1(A1)))) == CUDA.Adapt.adapt(Vector{T}, copy!(B2, B1))
             @test copy!(zA1, f1(A1)) == copy!(zA2, B1)
+            A3 = CuArray(randn(T, (m1, m2)))
+            A3c = copy(A3)
+            B3 = f1(StridedView(A3c))
+            @. B1 = 2 * B1 - B3 / 3 # test copyto! of Broadcasted
+            @. A1 = 2 * A1 - A3 / 3 # test copyto! of Broadcasted
+            @test CUDA.Adapt.adapt(Vector{T}, f1(A1)) == CUDA.Adapt.adapt(Vector{T}, B1)
             x = rand(T)
             @test f1(StridedView(CUDA.Adapt.adapt(Vector{T}, fill!(A1c, x)))) == CUDA.Adapt.adapt(Vector{T}, fill!(B1, x))
         end

--- a/test/jlarrays.jl
+++ b/test/jlarrays.jl
@@ -12,8 +12,11 @@
             axes(f1(A1)) == axes(f2(A2)) || continue
             @test collect(Matrix(copy!(f2(A2), f1(A1)))) == JLArrays.Adapt.adapt(Vector{T}, copy!(B2, B1))
             @test copy!(zA1, f1(A1)) == copy!(zA2, B1)
-            B1 .= 2 .* B1 .- B1 ./ 3 # test copyto! of Broadcasted
-            A1 .= 2 .* A1 .- A1 ./ 3 # test copyto! of Broadcasted
+            A3 = JLArray(randn(T, (m1, m2)))
+            A3c = copy(A3)
+            B3 = f1(StridedView(A3c))
+            @. B1 = 2 * B1 - B3 / 3 # test copyto! of Broadcasted
+            @. A1 = 2 * A1 - A3 / 3 # test copyto! of Broadcasted
             @test JLArrays.Adapt.adapt(Vector{T}, f1(A1)) == JLArrays.Adapt.adapt(Vector{T}, B1)
             x = rand(T)
             @test f1(StridedView(JLArrays.Adapt.adapt(Vector{T}, fill!(A1c, x)))) == JLArrays.Adapt.adapt(Vector{T}, fill!(B1, x))

--- a/test/jlarrays.jl
+++ b/test/jlarrays.jl
@@ -12,6 +12,9 @@
             axes(f1(A1)) == axes(f2(A2)) || continue
             @test collect(Matrix(copy!(f2(A2), f1(A1)))) == JLArrays.Adapt.adapt(Vector{T}, copy!(B2, B1))
             @test copy!(zA1, f1(A1)) == copy!(zA2, B1)
+            B1 .= 2 .* B1 .- B1 ./ 3 # test copyto! of Broadcasted
+            A1 .= 2 .* A1 .- A1 ./ 3 # test copyto! of Broadcasted
+            @test JLArrays.Adapt.adapt(Vector{T}, f1(A1)) == JLArrays.Adapt.adapt(Vector{T}, B1)
             x = rand(T)
             @test f1(StridedView(JLArrays.Adapt.adapt(Vector{T}, fill!(A1c, x)))) == JLArrays.Adapt.adapt(Vector{T}, fill!(B1, x))
         end


### PR DESCRIPTION
Needs tests but handles `copyto!` without scalar indexing. Definitely could be improved with some Cartesian indexing. Needed for the more complex index-manipulated TensorKit operations.