### PR TITLE
Add unit-stride fast path to _mapreduce_kernel!

### DIFF
--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -348,10 +348,8 @@ function _mapreduce_kernel_expr(f, op, initop, N::Int, M::Int)
     for j in 2:M
         push!(unitstep2ex.args, :($(Ivars[j]) += 1))
     end
-    unitstridecond = reduce(
-        (a, b) -> :($a && $b),
-        [:($(stridevars[1, j]) == 1) for j in 1:M]
-    )
+    firststrides = Expr(:tuple, (stridevars[1, j] for j in 1:M)...)
+    unitstridecond = :(all(==(1), $firststrides))
 
     if op == Nothing
         ex = Expr(:(=), lhsex, fcallex)

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -340,6 +340,23 @@ function _mapreduce_kernel_expr(f, op, initop, N::Int, M::Int)
         outerreturnstrideex[i] = returnex
     end
 
+    # Unit-stride fast path for the innermost (vectorized) loop dimension. The strides are
+    # runtime values, so even when the data is contiguous the compiler cannot prove unit
+    # stride and falls back to gather/scatter SIMD (which does not stream memory). When every
+    # array is contiguous along loop dimension 1 we instead step the parent indices by the
+    # literal `1`, letting the compiler emit contiguous SIMD loads/stores — up to ~3x faster
+    # for contiguous data. The post-loop index correction reuses the regular return-stride
+    # expressions, which are numerically identical here because the stride equals 1.
+    unitstep1ex = :($(Ivars[1]) += 1)
+    unitstep2ex = Expr(:block)
+    for j in 2:M
+        push!(unitstep2ex.args, :($(Ivars[j]) += 1))
+    end
+    unitstridecond = reduce(
+        (a, b) -> :($a && $b),
+        [:($(stridevars[1, j]) == 1) for j in 1:M]
+    )
+
     if op == Nothing
         ex = Expr(:(=), lhsex, fcallex)
         exa = Expr(:(=), :a, fcallex)
@@ -357,6 +374,14 @@ function _mapreduce_kernel_expr(f, op, initop, N::Int, M::Int)
                     $(stepstride2ex[i])
                 end
                 $lhsex = a
+                $(returnstride2ex[i])
+            elseif $unitstridecond
+                @simd for $(innerloopvars[i]) in Base.OneTo($(blockdimvars[i]))
+                    $ex
+                    $unitstep1ex
+                    $unitstep2ex
+                end
+                $(returnstride1ex[i])
                 $(returnstride2ex[i])
             else
                 @simd for $(innerloopvars[i]) in Base.OneTo($(blockdimvars[i]))

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -340,13 +340,9 @@ function _mapreduce_kernel_expr(f, op, initop, N::Int, M::Int)
         outerreturnstrideex[i] = returnex
     end
 
-    # Unit-stride fast path for the innermost (vectorized) loop dimension. The strides are
-    # runtime values, so even when the data is contiguous the compiler cannot prove unit
-    # stride and falls back to gather/scatter SIMD (which does not stream memory). When every
-    # array is contiguous along loop dimension 1 we instead step the parent indices by the
-    # literal `1`, letting the compiler emit contiguous SIMD loads/stores — up to ~3x faster
-    # for contiguous data. The post-loop index correction reuses the regular return-stride
-    # expressions, which are numerically identical here because the stride equals 1.
+    # Unit-stride fast path for the innermost (vectorized) loop dimension.
+    # We special-case for contiguous loads/stores to avoid SIMD gather/scatter
+    # in favor of SIMD load/store, which streams memory more efficiently.
     unitstep1ex = :($(Ivars[1]) += 1)
     unitstep2ex = Expr(:block)
     for j in 2:M


### PR DESCRIPTION
## Problem

`_mapreduce_kernel!` steps the parent indices of the innermost (vectorized) loop dimension by the arrays' strides, which are **runtime** values. Even when the data is contiguous, the compiler cannot prove unit stride, so LLVM auto-vectorizes the inner loop with **gather/scatter** instructions (`vgatherqpd`/`vscatterqpd`). Gather/scatter address each lane individually and do not stream memory.

The effect is severe for memory-bound contiguous ops. A contiguous `400×400` Float64 `copy!` (`map!(identity, …)`) runs at ~8.5 GB/s (~300 µs) instead of the ~33 GB/s a contiguous SIMD loop achieves. Minimal reproduction — a hand-written `@simd` copy loop:

| inner loop (160 000 elems) | time | asm |
|---|---|---|
| `C[i]=A[i]`, **runtime** stride (=1) | 298 µs | gather/scatter |
| `C[i]=A[i]`, **compile-time** stride `1` | 91 µs | contiguous |

Pure-copy / `map!` bodies are hit hardest because LLVM's cost model judges gather/scatter SIMD "profitable" for them, whereas heavier accumulate bodies are left as (faster) scalar loops.

## Change

Add a runtime branch in the innermost loop: when **every array is contiguous along loop dimension 1** (all innermost strides `== 1`), step the parent indices by the literal `1` instead of the runtime stride. This lets the compiler emit streaming SIMD loads/stores. The post-loop index correction reuses the existing return-stride expressions, which are numerically identical because the stride equals `1`.

The change is confined to the generated expression for the non-reduction innermost loop; non-contiguous (e.g. transposed) inputs are unaffected and take the existing path.

## Results

Contiguous `400×400` Float64, single thread:

| op | before | after |
|---|---|---|
| `copy!` (contiguous) | ~300 µs | **~91 µs (~3.3×)** |
| `copy!` (transposed input) | ~293 µs | ~259 µs (unchanged path) |

The contiguous result now matches the compile-time-constant-stride ideal.

## Testing

- Full Strided test suite passes, single- and multi-threaded (`JULIA_NUM_THREADS=4`): `map`/`scale!`/`axpy!`/`axpby!`, `copy`, `broadcasting`, `mapreduce`, `reduce`, `mul!`.
- Additional correctness sweep (81 cases over Float32/Float64/ComplexF64 × ndims 1–4, covering `copy!`/`conj!`/permuted copies/scaled `map!`/binary `map!`/reductions/axpby): max error `0.0`.

## Notes / possible follow-ups

- Reduction loops (the `iszero(stride)` hoist branch) still gather contiguous **inputs** (e.g. `sum` over a contiguous array). An analogous unit-stride branch there would help; left out to keep this change focused.
- The gather/scatter code path remains in the binary as the fallback for the genuinely strided case; only the runtime branch taken for contiguous data changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)