### PR TITLE
Release v2.6.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Strided"
 uuid = "5e0ebb24-38b0-5f93-81fe-25c709ecae67"
-version = "2.6.1"
+version = "2.6.2"
 authors = ["Lukas Devos <lukas.devos@ugent.be>", "Maarten Van Damme <maartenvd1994@gmail.com>", "Jutho Haegeman <jutho.haegeman@ugent.be>"]
 
 [deps]


### PR DESCRIPTION
A performance-focused patch release that reduces compilation time and with small improvements to the `mapreduce` kernels.

### Highlights
- **Faster compilation:** `@nospecialize` added to the `mapreduce` dispatch chain (#66) and `blas_mul!` de-specialized (#73) to cut compile time.
- **Faster reductions:** added a unit-stride fast path to `_mapreduce_kernel!` and specialized the non-reducing kernel by dropping the reduction-only `iszero` hoist (#69).
- **Kernel ordering:** improved loop ordering in the mapreduce kernel — "order → fuse → order" (#74).
- Minor internal cleanups (simplified `firststride` condition, improved comments) and CI maintenance (bump `actions/checkout` 6 → 7, #68).

### Full Changelog
See the [commit history](https://github.com/QuantumKitHub/Strided.jl/compare/v2.6.1...v2.6.2) for the complete list of changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
