### PR TITLE
Use the CODECOV_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,6 @@ jobs:
       - uses: codecov/codecov-action@v7
         with:
           files: lcov.info
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         


### PR DESCRIPTION
we're currently not uploading coverage from any GitHub CI run